### PR TITLE
price is scraped to be an integer (price sort works) and etsy name scrape limited to all characters up to .,-

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -70,10 +70,11 @@ private
     html_doc = Nokogiri::HTML(html_file)
 
     if @url.include?('etsy')
-      name = html_doc.search('.wt-text-body-03.wt-line-height-tight.wt-break-word').text.strip
+      name = html_doc.search('.wt-text-body-03.wt-line-height-tight.wt-break-word').text.strip.split(/[.,\-]/).first
       description = html_doc.search("#product-details-content-toggle > div > ul").text.strip
-      price = html_doc.search('.wt-text-title-03.wt-mr-xs-2').text.strip.match(/£?€?\d+.\d{2}/)
-      original_price = html_doc.search('.wt-text-strikethrough.wt-text-caption.wt-text-gray.wt-mr-xs-1').text.strip.match(/£?€?\d+.\d{2}/)
+      currency = html_doc.search('.wt-text-title-03.wt-mr-xs-2').text.strip.match(/[£€]/).to_s
+      price = html_doc.search('.wt-text-title-03.wt-mr-xs-2').text.strip.match(/\d+.\d{2}/).to_s.sub(".","").to_i
+      original_price = html_doc.search('.wt-text-strikethrough.wt-text-caption.wt-text-gray.wt-mr-xs-1').text.strip.match(/\d+.\d{2}/).to_s.sub(".","").to_i
       elements = []
       html_doc.search('.wt-position-absolute.wt-width-full.wt-height-full.wt-position-top.wt-position-left.carousel-pane img').each do |element|
         image = element["src"]
@@ -86,7 +87,8 @@ private
       name_product = html_doc.search('.product-name span').text.strip
       name = "#{name_brand} - #{name_product}"
       description = html_doc.search('.pa1.product-description').text.strip
-      price = html_doc.search('.price-box span span').first.text.strip
+      currency = html_doc.search('.price-box span span').text.strip.match(/[£€]/).to_s
+      price = html_doc.search('.price-box span span').first.text.strip.chars.select {|x| x.to_i.to_s == x}.join.to_i*100
       elements = []
       html_doc.search('.gallery-image').each do |element|
         image = "https:#{element["src"]}"
@@ -101,7 +103,8 @@ private
       price: price,
       description: description,
       image_url: image_url,
-      original_price: original_price
+      original_price: original_price,
+      currency: currency
     }
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -9,7 +9,7 @@
 
   <div class="pt-4 pb-4">
     <%= form_tag items_path, method: :get do  %>
-      <%= select_tag(:sort, options_for_select([["Alphabetical", :name],["Highest Price", :price],["Oldest",:created_at]], params[:sort]), include_blank: true)
+      <%= select_tag(:sort, options_for_select([:name,:price,:created_at], params[:sort]), include_blank: true)
         # params[:sort]
         # class: "form-control"
       %>
@@ -41,7 +41,7 @@
     <img src=<%= item.image_url %> class="card-img-top" width = "50px" height = "150px">
       <div class="card-body>
         <h5 class="card-title"><%= item.name %></h5>
-        <p class="card-text">Price: <%= item.price %> <s> <%= (item.original_price) ? item.original_price : ""%></s> </p>
+        <p class="card-text">Price: <%= "#{item.currency}#{'%.2f' % (item.price.to_f/100).to_s}" %> <s> <%= (item.original_price.to_i)>0 ? "#{item.currency}#{item.original_price.to_f/100}" : ""%></s> </p>
         <p> Category: <%= item.category.name %>  </p>
       </div>
       <div class="card-footer">

--- a/db/migrate/20220301180835_change_price_to_be_string_in_items.rb
+++ b/db/migrate/20220301180835_change_price_to_be_string_in_items.rb
@@ -1,5 +1,5 @@
-class ChangePriceToBeStringInItems < ActiveRecord::Migration[6.1]
+class ChangePriceToBeIntegerInItems < ActiveRecord::Migration[6.1]
   def change
-    change_column :items, :price, :string
+    change_column :items, :price, :integer
   end
 end

--- a/db/migrate/20220305124247_add_currency_to_items.rb
+++ b/db/migrate/20220305124247_add_currency_to_items.rb
@@ -1,0 +1,5 @@
+class AddCurrencyToItems < ActiveRecord::Migration[6.1]
+  def change
+    add_column :items, :currency, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_01_201843) do
+ActiveRecord::Schema.define(version: 2022_03_05_124247) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 2022_03_01_201843) do
 
   create_table "items", force: :cascade do |t|
     t.string "name"
-    t.string "price"
+    t.integer "price"
     t.text "description"
     t.text "item_url"
     t.text "image_url"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 2022_03_01_201843) do
     t.bigint "category_id"
     t.bigint "user_id"
     t.string "original_price"
+    t.string "currency"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["user_id"], name: "index_items_on_user_id"
   end


### PR DESCRIPTION
1. Added currency to schema to allow me to split on regex 
2. Price is now an integer on schema
3. Scrape turns items from both websites into pennies and then we convert into £x.yz on front end - price sort works
4. limited for now item name scrape to all characters up to the first -,. ... might look to change as per Fang's suggestion (e.g. first x number of characters)